### PR TITLE
ci: disable npm publish for release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -15,7 +15,7 @@
     "push": false
   },
   "npm": {
-    "publish": true,
+    "publish": false,
     "publishArgs": [
       "--provenance"
     ]


### PR DESCRIPTION
For now since release-it workflow is developed the npm publish is disabled