### PR TITLE
ci(release): remove release tag step in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,6 @@ jobs:
       - name: Create commit message
         run: |
           echo "chore: release $(jq -r '.version' package.json)" > commitMessageFile
-      - name: Extract new version
-        id: version
-        run: echo "new=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
       - name: Commit changes
         uses: iarekylew00t/verified-bot-commit@2a9d9e983e611793b54516a18e48361bbac691d9 # v1.4.1
         id: commit
@@ -84,18 +81,6 @@ jobs:
             CHANGELOG.md
             package.json
             package-lock.json
-      - name: Create Tag
-        run: |
-          curl -X POST \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${{ github.repository }}/git/refs \
-            -d @- <<EOF
-          {
-            "ref": "refs/tags/${{ steps.version.outputs.new }}",
-            "sha": "${{ steps.commit.outputs.commit }}"
-          }
-          EOF
       - name: Attest
         uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
         with:


### PR DESCRIPTION
Tag is already created by release-it because the release on github can only be applied to a tag.